### PR TITLE
Corrected ticket amount display at checkout

### DIFF
--- a/src/server/api/routers/ticket.ts
+++ b/src/server/api/routers/ticket.ts
@@ -92,9 +92,20 @@ export const ticketRouter = createTRPCRouter({
       return null;
     }
 
+    // Count paid sold tickets for this reserve
+    const soldTicketsCount = await ctx.db.soldTickets.count({
+      where: {
+        reserveId: matchingReserve.id,
+        paid: true,
+      },
+    });
+
+    // Calculate available tickets: reserve amount minus sold tickets
+    const availableAmount = Math.max(0, matchingReserve.amount - soldTicketsCount);
+
     return {
       id: matchingReserve.id,
-      amount: matchingReserve.amount,
+      amount: availableAmount,
       price: matchingReserve.price,
       type: matchingReserve.type[0]?.name || "Unknown",
       groupId: matchingReserve.type[0]?.id || 0,


### PR DESCRIPTION
Reworked ticket router to return the correct amount.
Old = blank amount of reserve
New = calculated available amount (amount - soldtickets count)

Befor these changes the buyer could always choose his max amount of tickets - even if none or one are available (given the total reserve max is equal or greater).
Now if the users max tickets is 2 and only 1 ticket is available (but 200 total reserve max) the user can only buy one.
